### PR TITLE
feat:feedback_asuka

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict, Any
 from app.api.deps import get_session, get_current_user
 from app.schemas.team import UserOut
 from app.models.user import User
-from app.models.team_member import TeamMember  # ← ここがポイント
+from app.models.team_member import TeamMember  
 
 router = APIRouter()  # prefix は api.py 側で付与
 
@@ -68,5 +68,7 @@ async def get_user_detail(
             "respected_person": _val(prof, "respected_person"),
             "motto": _val(prof, "motto"),
             "future_goals": _val(prof, "future_goals"),
+            "feedback": prof.get("feedback"),
+            "ai_analysis": prof.get("ai_analysis"),
         },
     )

--- a/backend/app/schemas/team.py
+++ b/backend/app/schemas/team.py
@@ -46,6 +46,10 @@ class UserProfileOut(BaseModel):
     total_speaking_time_seconds: Optional[int] = None
     last_analysis_at: Optional[str] = None
 
+    # AI分析フィードバック関連
+    feedback: Optional[List[str]] = None
+    ai_analysis: Optional[Dict[str, Any]] = None
+
     if _V2:
         model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/components/team/MemberDetail.tsx
+++ b/frontend/src/components/team/MemberDetail.tsx
@@ -20,6 +20,7 @@ import {
   Star,
   Quote,
   Target,
+  MessageSquare,
 } from "lucide-react";
 
 type Props = { memberId: string };
@@ -107,6 +108,43 @@ export function MemberDetail({ memberId }: Props) {
           ))}
         </ul>
       </section>
+
+             {/* フィードバック一覧 */}
+       {p.feedback && p.feedback.length > 0 ? (
+        <section className="border-t pt-6">
+                     <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+             <MessageSquare className="h-5 w-5 text-green-600" />
+             フィードバック一覧
+           </h3>
+          
+          {/* フィードバック一覧 */}
+          {p.feedback && p.feedback.length > 0 && (
+            <div className="mb-6">
+              <h4 className="text-md font-medium text-gray-800 mb-3 flex items-center gap-2">
+                <MessageSquare className="h-4 w-4 text-green-600" />
+                フィードバック一覧
+              </h4>
+              <div className="space-y-3">
+                {p.feedback.map((feedback, index) => (
+                  <div key={index} className="bg-green-50 border border-green-200 rounded-lg p-3">
+                    <p className="text-sm text-green-800">{feedback}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+
+        </section>
+      ) : (
+                 <section className="border-t pt-6">
+           <div className="text-center text-gray-500 py-8">
+             <MessageSquare className="h-12 w-12 mx-auto text-gray-300 mb-3" />
+             <p className="text-sm">フィードバックはまだありません</p>
+             <p className="text-xs text-gray-400 mt-1">マイプロフィールでフィードバックを登録すると表示されます</p>
+           </div>
+         </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -34,6 +34,21 @@ export type MemberProfile = {
   total_chat_sessions?: number | null;
   total_speaking_time_seconds?: number | null;
   last_analysis_at?: string | null;
+
+  // AI分析フィードバック関連
+  feedback?: string[] | null;
+  ai_analysis?: {
+    collaboration_score?: number | null;
+    leadership_score?: number | null;
+    empathy_score?: number | null;
+    assertiveness_score?: number | null;
+    creativity_score?: number | null;
+    analytical_score?: number | null;
+    communication_style?: string | null;
+    team_dynamics_insights?: string | null;
+    improvement_suggestions?: string[] | null;
+    last_updated?: string | null;
+  } | null;
 };
 
 export type TeamMember = {


### PR DESCRIPTION
# プルリクエスト

## 概要
編集画面で保存したフィードバック一覧を、メンバー詳細画面に表示するよう実装しました

## 変更内容
- [ ]  AI分析フィードバック用のフィールドを追加
- [ ] メンバー詳細画面にAI分析フィードバックセクションを追加
- [ ] バックエンドのスキーマを更新
- [ ] バックエンドのユーザー詳細APIを更新
- [ ] フィードバックデータがない場合のメッセージを表示

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
Closes #87 

## チェックリスト
- [ ] コードレビューを依頼しました

## 注意事項
・まだデータが未投入なので表示項目はありません。
プロフィール編集画面が実装でき次第、動作確認を行ないます。
